### PR TITLE
Change target SOC entity's object

### DIFF
--- a/custom_components/volkswagen_we_connect_id/number.py
+++ b/custom_components/volkswagen_we_connect_id/number.py
@@ -64,7 +64,7 @@ class TargetSoCNumber(VolkswagenIDBaseEntity, NumberEntity):
         """Return the value reported by the number."""
         return int(
             get_object_value(
-                self.data.domains["charging"]["chargingSettings"].targetSOC_pct.value
+                self.data.domains["charging"]["chargingSettings"].currentSOC_pct.value
             )
         )
 


### PR DESCRIPTION
Update the name of the object which would be pulled from the API but nonexistent on e-up (MBB platform in API). With my minimal python skills I picked the only number returned by the API and used it instead of the nonexistent, to keep Home Assistant from crashing internally. The setup went through without any issues after this.